### PR TITLE
Optional pagination with defaults

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,7 +94,7 @@ curl -X POST https://api.stackslurper.xyz/graphql \
         totalItemsCount
         totalPageCount
       }
-      leads {
+      records {
         id
         name
         email
@@ -110,6 +110,36 @@ curl -X POST https://api.stackslurper.xyz/graphql \
       "limit": 2
     }
   }
+}
+EOF
+```
+
+The pagination args are optional, and default to `page: 1` and `limit: 10`. This is not yet deployed,
+thus this will only work on local.
+
+```sh
+# Please use http://localhost:3001 on local
+curl -X POST http://localhost:3001/graphql \
+  -H "Content-Type: application/json" \
+  -H "Accept: application/json" \
+  -d @- <<EOF # | jq   # Uncomment to pretty-print if you have jq installed
+{
+  "query": "query GetLeads {
+    leads {
+      pageInfo {
+        totalItemsCount
+        totalPageCount
+      }
+      records {
+        id
+        name
+        email
+        servicesInterestedIn {
+          name
+        }
+      }
+    }
+  }"
 }
 EOF
 ```
@@ -192,7 +222,7 @@ curl -X POST https://api.stackslurper.xyz/graphql \
         totalItemsCount
         totalPageCount
       }
-      leads {
+      records {
         id
         name
         email

--- a/src/leads/lead.resolver.ts
+++ b/src/leads/lead.resolver.ts
@@ -23,7 +23,7 @@ export class LeadResolver {
   })
   async getLeads(
     @Args('listLeadsInput', { nullable: true })
-    listLeadsInput: ListLeadsInput = new ListLeadsInput({ page: 1, limit: 10 }),
+    listLeadsInput: ListLeadsInput = new ListLeadsInput(),
   ): Promise<ListLeadsResult> {
     const [leads, totalCount] = await this.leadService.findAndCountLeads(listLeadsInput);
     return new ListLeadsResult(leads, totalCount, listLeadsInput.page, listLeadsInput.limit);

--- a/src/leads/lead.resolver.ts
+++ b/src/leads/lead.resolver.ts
@@ -21,7 +21,10 @@ export class LeadResolver {
       'Retrieve a page of leads. This has no authentication for demo purposes, if it creates ' +
       'friction for the exercise.',
   })
-  async getLeads(@Args('listLeadsInput') listLeadsInput: ListLeadsInput): Promise<ListLeadsResult> {
+  async getLeads(
+    @Args('listLeadsInput', { nullable: true })
+    listLeadsInput: ListLeadsInput = new ListLeadsInput({ page: 1, limit: 10 }),
+  ): Promise<ListLeadsResult> {
     const [leads, totalCount] = await this.leadService.findAndCountLeads(listLeadsInput);
     return new ListLeadsResult(leads, totalCount, listLeadsInput.page, listLeadsInput.limit);
   }

--- a/src/leads/models/list-leads-result.model.ts
+++ b/src/leads/models/list-leads-result.model.ts
@@ -16,10 +16,10 @@ export class ListLeadsResult {
   /**
    * The list of leads for the current page.
    */
-  leads: Lead[];
+  records: Lead[];
 
   constructor(leads: Lead[], totalItemsCount: number, currentPage: number, itemsPerPage: number) {
     this.pageInfo = createPaginationMetadata(totalItemsCount, currentPage, itemsPerPage);
-    this.leads = leads;
+    this.records = leads;
   }
 }

--- a/src/leads/models/list-leads.input.ts
+++ b/src/leads/models/list-leads.input.ts
@@ -22,7 +22,7 @@ export class ListLeadsInput {
   @IsPositive()
   limit: number = 10;
 
-  constructor(data: Partial<ListLeadsInput>) {
+  constructor(data: Partial<ListLeadsInput> = {}) {
     Object.assign(this, data);
   }
 }


### PR DESCRIPTION
No ticket.

### PR Summary

- renames `leads` of `ListLeadsResult` to `records`, to avoid the confusing inner `leads` inside the query also named `leads`.
- the `listLeadsInput` arg is now optional, and allows the following:
   ```diff
  {
      "query": "query GetLeads {
        leads {
          pageInfo {
            totalItemsCount
            totalPageCount
          }
  -       leads {
  +       records {
            id
            name
            email
            servicesInterestedIn {
              name
            }
          }
        }
      }"
    }
    ```